### PR TITLE
docker-entrypoint.shを整備します

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,4 +88,5 @@ RUN \
 USER wallet
 VOLUME ["${XPD_DATA_DIR}"]
 EXPOSE 28191 28192
-CMD ["/usr/local/bin/XPd", "--datadir=${XPD_DATA_DIR}"]
+ENTRYPOINT ["/home/wallet/docker-entrypoint.sh"]
+CMD ["/usr/local/bin/XPd"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,17 +10,29 @@ FILEID="1DZx3mzj81MYwV1QXtGXTEQ-1CXFfaHUX"
 ZIP_TEMP_FILE=bootstrap.zip
 ZIP_TEMP_DIR=ziptemp
 
+_init_datafiles() {
+	echo "Initializing data files..."
+	timeout 3 XPd
+	echo "done"
+}
+
 _download_from_gdrive() {
+	echo "Downloading bootstrap..."
 	curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=$1" > /dev/null
 	local download_code="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
 	curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${download_code}&id=$1" -o $2
+	echo "done"
 }
 
 _download_from_dropbox() {
+	echo "Downloading bootstrap..."
 	curl -Ls "https://www.dropbox.com/s/wz8sg14ujmx1dnm/xpcoin-bootstrap-peers.zip?dl=0" -o $1
+	echo "done"
 }
 
 _deploy_bootstrap() {
+	echo "Extracting bootstrap..."
+	rm -f ${XPD_DATA_DIR}/database/*
 	rm -fr $2/*
 	unzip -d $2 $1
 	for CONTENT_FILE in $(find ${2} -type f -and -not -name readme.txt -and -not -name xpcoin-startkit_v1.0.bat -and -not -name wallet.dat)
@@ -29,9 +41,11 @@ _deploy_bootstrap() {
 	done
 	rm -fr $2
 	rm -f $1
+	echo "done"
 }
 
 if [ ! -d ${XPD_DATA_DIR}/database ]; then
+	_init_datafiles
 	_download_from_dropbox bootstrap-latest.zip
 	_deploy_bootstrap bootstrap-latest.zip ziptemp
 fi


### PR DESCRIPTION
- curlなどのメッセージを減らし、echoでの進捗メッセージのみにします
- 初期データを作成するため、3秒間だけXPdを起動して終了します
- 上記に伴い`~/.XPd/database/log.0000000001`が作成されるため、bootstrap展開時に削除します
- Dockerコンテナ起動時にdocker-entrypoint.shが実行されるようにします