### PR TITLE
起動時に時間がかかるのは初回に限らないのでメッセージを変更します

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -84,7 +84,7 @@ if [ ! -d ${XPD_DATA_DIR}/database ]; then
 	_deploy_bootstrap bootstrap-latest.zip ziptemp
 	_update_init_node
 	echo "All initialize process has be done. Proceed to boot XPd."
-	echo "On first boot, it will take over 10 minutes or more. Please wait patiently."
 fi
 
+echo "When XPd is starting, it may take over 10 minutes or more. Please wait patiently."
 exec "$@"


### PR DESCRIPTION
bootstrapを当てた後や、同期が住んでいる状態で起動すると時間がかかるのはblkindex.datなどのGBクラスのファイルを読み込むのに時間がかかっているように見られる。

各データファイルがSSDにあるとかなり改善するが、メッセージは起動毎に表示することとする。