### PR TITLE
Docker Cloud automated build対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:xenial
 
-# Change APT source and set locale
-RUN \
-  sed -i".bak" \
-    "s@http://archive\.ubuntu\.com@http://ftp\.riken\.go\.jp/Linux/ubuntu@" \
-    /etc/apt/sources.list
+# Change APT source
+# RUN \
+#   sed -i".bak" \
+#     "s@http://archive\.ubuntu\.com@http://ftp\.riken\.go\.jp/Linux/ubuntu@" \
+#     /etc/apt/sources.list
 
 # Install gosu
 ENV GOSU_VERSION 1.10
@@ -34,20 +34,17 @@ RUN set -ex; \
   \
 	apt-get purge -y --auto-remove $fetchDeps
 
-# Basic settings (Locales, timezone, etc)
+# Basic settings
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     apt-utils && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    language-pack-ja language-pack-en tzdata software-properties-common && \
+    language-pack-en tzdata software-properties-common && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  update-locale LANG=ja_JP.UTF-8 && \
-  ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-  dpkg-reconfigure --frontend noninteractive tzdata
+  update-locale LANG=en_US.UTF-8
 ENV \
-  LANG=ja_JP.utf8 \
   XPD_DATA_DIR=/home/wallet/.XP
 
 # Create a normal user

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,106 @@
+# XPd (XPCoinウォレット) Dockerイメージ
+
+XPd(XPCoinウォレット)をDocker化します。
+
+## Description
+
+XPdはXPdウォレットという名で知られるXPCoinのデーモンプログラムです。
+
+このDockerイメージではXPdをビルドしたものに加え、下記の機能を追加しています。
+
+- 初回起動時にブートストラップを自動でダウンロードし、配置します。
+- 初期設定のノード情報をXP-JPチームが提供しているノードに置き換えます。
+
+## 使い方
+
+### A. docker-composeを使う場合
+
+docker-composeが使える状態であることが前提です。
+
+起動:
+
+1. docker-compose.ymlをダウンロードします。Gitリポジトリをcloneする必要はありません。
+1. `docker-compose up -d`を実行してXPdを起動します。
+1. 必要に応じて`docker-compose logs wallet`でログを表示します。
+
+```shell
+$ curl -L https://raw.githubusercontent.com/moochannel/xp-wallet-docker/master/docker-compose.yml -o docker-compose.yml     #  (1)
+$ docker-compose up -d            #  (2)
+
+$ docker-compose logs -f wallet   #  (3)
+```
+
+終了:
+
+1. `docker-compose stop`を実行してコンテナを停止します。
+
+```shell
+$ docker-compose stop       #  (1)
+$ docker-compose rm         #  必要に応じて
+or
+$ docker-compose down       #  上記2つのコマンドをまとめて実行します
+```
+
+#### おすすめの設定
+
+Dockerボリュームについて:
+
+XPdのデータファイル(ウォレットデータを含む)はDockerボリュームに配置されます。
+Dockerボリュームを削除してしまうとウォレットデータも消えてしまいます。
+
+下記のようにdocker-compose.ymlを編集し、ホストのディレクトリをコンテナに
+直接マウントすることを勧めます。
+
+```
+volumes:
+  wallet-data:
+↓
+volumes:
+  wallet-data:
+    type: none
+    device: /path/to/data_dir
+    o: bind
+```
+
+この設定では`docker-compose down -v`や`docker volume prune`といった
+Dockerコマンドでボリュームを削除してしまっても、データそのものはホストの
+データディレクトリに残ります。
+
+公開するポートについて:
+
+28192/tcp ポートだけを開けましょう。
+
+Dockerfileでは 28191/tcp もEXPOSEに記載していますが、このポートはRPCで
+使用するもので、世界中から接続できるようにする必要はほぼありません。
+
+### B. docker-composeを使わない場合
+
+`docker-compose.yml`ファイル無しでもXPdコンテナを起動することは可能です。
+
+起動:
+
+1. `docker run -d [options] moochannel/xpd`を実行してXPdを起動します。
+1. 必要に応じて`docker logs -f <コンテナID>`でログを表示します。
+
+```shell
+$ docker run -d -v </path/to/dir>:/home/wallet/.XP -p 28192:28192 moochannel/xpd    #  (1)
+$ docker ps                     #  コンテナIDを調べます
+$ docker logs -f <コンテナID>   #  (2)
+```
+
+Stop:
+
+1. `docker stop`を実行してコンテナを停止します。
+
+```shell
+$ docker stop <コンテナID>    #  (1)
+$ docker rm <コンテナID>      #  as you need.
+```
+
+## License
+
+[MIT](https://github.com/moochannel/xp-wallet-docker/blob/master/LICENSE)
+
+## Author
+
+[moochannel](https://github.com/moochannel)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,101 @@
-# xp-wallet-docker
-XPのウォレット(XPd)をDocker化します
+# XPd (XPCoin Wallet) runs inside a Docker container
+
+Dockerized XPCoin Wallet
+
+## Description
+
+XPd is an XPCoin daemon program aka XPCoin Wallet.
+
+This docker image contains XPd and some additional features:
+
+- Download and deploy XP bootstrap files on first boot.
+- Replace initial XPd nodes with what XP-JP team provide ones.
+
+## How to use
+
+### A. With docker-compose
+
+(Are you ready to use docker-compose?)
+
+Start:
+
+1. Download docker-compose.yml file. You don't need clone this repository.
+1. Run daemon with `docker-compose up -d` command.
+1. Watch container log with `docker-compose logs wallet` as you need.
+
+```shell
+$ curl -L https://raw.githubusercontent.com/moochannel/xp-wallet-docker/master/docker-compose.yml -o docker-compose.yml     #  (1)
+$ docker-compose up -d              #  (2)
+
+$ docker-compose logs -f wallet     #  (3)
+```
+
+Stop:
+
+1. Stop daemon with `docker-compose stop` command.
+
+```shell
+$ docker-compose stop       #  (1)
+$ docker-compose rm         #  as you need
+or
+$ docker-compose down       #  same as above two commands
+```
+
+#### Recommend settings
+
+Docker volume:
+
+XPd's data files (include Wallet data) are placed in docker volume. If you remove volume, your wallet will go away.
+
+So I suggest mounting host directory with edit docker-compose.yml file.
+
+```
+volumes:
+  wallet-data:
+↓
+volumes:
+  wallet-data:
+    type: none
+    device: /path/to/data_dir
+    o: bind
+```
+
+With this setting, even if you remove the volume with docker commands like `docker-compose down -v` or `docker volume prune`, the payload of the data directory will remain in the host.
+
+Publish ports:
+
+Just only open 28192/tcp port.
+
+28191/tcp is also exposed in Dockerfile, but it is used as RPC. It is not needed to be connected from worldwide in many cases.
+
+### B. Without docker-compose
+
+You can run XPd container without `docker-compose.yml` file.
+
+Start:
+
+1. Run daemon with `docker run -d [options] moochannel/xpd` command.
+1. Watch container log with `docker logs -f <container-id>` as you need.
+
+```shell
+$ docker run -d -v </path/to/dir>:/home/wallet/.XP -p 28192:28192 moochannel/xpd        #  (1)
+$ docker ps     #  Looking for container id
+$ docker logs -f <container-id>     #  (2)
+```
+
+Stop:
+
+1. Stop daemon with `docker stop` command.
+
+```shell
+$ docker stop <container-id>    #  (1)
+$ docker rm <container-id>      #  as you need.
+```
+
+## License
+
+[MIT](https://github.com/moochannel/xp-wallet-docker/blob/master/LICENSE)
+
+## Author
+
+[moochannel](https://github.com/moochannel)


### PR DESCRIPTION
Dockerイメージの作成をDocker Cloudで行うので、APTのリポジトリを日本国内に変更するといったものは不要になります。

あわせてREADMEも整備します。

This fixes #6 